### PR TITLE
fix: some error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Homestead.json
 /.vagrant
 /.phpunit.cache
 .phpunit.result.cache
+.idea

--- a/src/Commands/DocumentFacades.php
+++ b/src/Commands/DocumentFacades.php
@@ -38,7 +38,7 @@ class DocumentFacades extends Command
         $result = Process::run(sprintf(
             'php -f vendor/bin/facade.php -- %s',
             $this->getFacades()->map(
-                fn (string $class) => str_replace('\\', '\\\\', $class)
+                fn (string $class) => windows_os() ? $class : str_replace('\\', '\\\\', $class)
             )->join(' ')
         ));
 
@@ -89,10 +89,13 @@ class DocumentFacades extends Command
             return null;
         }
 
-        if (! preg_match('/^namespace (.*);$/', array_shift($namespaces), $match)) {
+        $namespace = array_shift($namespaces);
+        $namespace = trim($namespace);
+
+        if (! preg_match('/^namespace (?P<namespace>.*);$/', $namespace, $match)) {
             return null;
         }
 
-        return array_pop($match);
+        return $match['namespace'];
     }
 }


### PR DESCRIPTION
- double slash not work on php windows
- namespace contain endline at end, `/^namespace (?P<namespace>.*);$/` alway return null

![image](https://github.com/stevebauman/autodoc-facades/assets/18243451/14e361ac-0755-4b45-9d75-1cae95f14b5a)
